### PR TITLE
Add github workflows for releasing and templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,90 @@
+name: "Bug report 🐛"
+description: Report an issue with IFC.js fragment
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report! <img src="https://ifcjs.github.io/info/img/logo.svg" width="16">
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Describe the bug 📝
+      description: A clear and concise description of what the bug is. If you intend to submit a PR for this issue, tell us in the description. Thanks!
+      placeholder: |
+        I am doing ...
+        What I expect is ...
+        What is actually happening is...
+    validations:
+      required: true
+  - type: input
+    id: reproduction
+    attributes:
+      label: Reproduction ▶️
+      description: If possible, please provide an [asciinema record](https://asciinema.org/) or a link to a repo that can reproduce the problem you ran into. A [minimal reproduction](https://stackoverflow.com/help/minimal-reproducible-example) is desirable. If a report is vague (e.g. just a generic error message) and has no reproduction, solving it will also be a slower or unfeasible process.
+      placeholder: Reproduction URL
+    validations:
+      required: false
+  - type: textarea
+    id: reproduction-steps
+    attributes:
+      label: Steps to reproduce 🔢
+      description: Please provide any reproduction steps that may need to be described.
+      placeholder: |
+        1. Run `npm install`.
+        2. ...
+    validations:
+      required: false
+  - type: textarea
+    id: system-info
+    attributes:
+      label: System Info 💻
+      description: Output of `npx envinfo --system --npmPackages 'bim-fragment' --binaries --browsers`
+      render: shell
+      placeholder: System, Binaries, Browsers
+    validations:
+      required: true
+  - type: dropdown
+    id: package-manager
+    attributes:
+      label: Used Package Manager 📦
+      description: Select the used package manager
+      options:
+        - npm
+        - yarn
+        - pnpm
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Error Trace/Logs 📃
+      description: |
+        Optional if provided reproduction. Please try not to insert an image but copy paste the error trace/logs text.
+
+        Provide the error log here in the format below:
+        ````
+        <details>
+        <summary>Click to expand!</summary>
+
+        ```shell
+        // paste the log text here
+        ```
+        </details>
+        ````
+  - type: checkboxes
+    id: checkboxes
+    attributes:
+      label: Validations ✅
+      description: "Before submitting the issue, please make sure that you have:"
+      options:
+        - label: Read the [docs](https://ifcjs.github.io/info/docs/Introduction).
+          required: true
+        - label: Check that there isn't [already an issue](https://github.com/IFCjs/fragment/issues) that reports the same bug to avoid creating a duplicate.
+          required: true
+        - label: Make sure this is a IFC.js fragment issue and not a framework-specific issue. For example, if it's a THREE.js related bug, it should likely be reported to [mrdoob/threejs](https://github.com/mrdoob/three.js) instead.
+          required: true
+        - label: Check that this is a concrete bug. For Q&A join our [Discord Chat Server](https://discord.gg/FXfyR4XrKT).
+          required: true
+        - label: The provided reproduction is a [minimal reproducible example](https://stackoverflow.com/help/minimal-reproducible-example) of the bug.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+contact_links:
+  - name: Discord Chat
+    url: https://discord.gg/FXfyR4XrKT
+    about: Join the official Discord server and discuss with other IFC.js members in real time.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,48 @@
+name: "New feature proposal 🚀"
+description: Propose a new feature to be added to IFC.js fragment
+labels: [feature]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for your interest in the project and taking the time to fill out this feature report! <img src="https://ifcjs.github.io/info/img/logo.svg" width="16">
+  - type: textarea
+    id: feature-description
+    attributes:
+      label: Description 📝
+      description: "Clear and concise description of the problem. Please make the reason and usecases as detailed as possible. If you intend to submit a PR for this issue, tell us in the description. Thanks!"
+      placeholder: "Example: As a BIM developer/engineer using IFC.js I want [goal / wish] so that [benefit]."
+    validations:
+      required: true
+  - type: textarea
+    id: suggested-solution
+    attributes:
+      label: Suggested solution 💡 
+      description: If possible, include in this field a solution or approach that would solve or implement the described feature.
+      placeholder: "In module/component [xy] we could provide the following implementation..."
+    validations:
+      required: false
+  - type: textarea
+    id: alternative
+    attributes:
+      label: Alternative ⛕
+      description: Clear and concise description of any alternative solutions or features you've considered.
+    validations:
+      required: false
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context ☝️
+      description: Any other context or screenshots about the feature request here.
+    validations:
+      required: false
+  - type: checkboxes
+    id: checkboxes
+    attributes:
+      label: Validations ✅
+      description: "Before submitting the issue, please make sure that you have:"
+      options:
+        - label: Read the [docs](https://ifcjs.github.io/info/docs/Introduction).
+          required: true
+        - label: Check that there isn't [already an issue](https://github.com/IFCjs/fragment/issues) that requests the same feature to avoid creating a duplicate.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+<!-- Thanks you so much for your PR, your contribution is appreciated! ❤️ -->
+
+### Description
+
+<!-- Please insert your description here. Make sure to provide info about the "what" this PR is solving -->
+<!-- Remember to include which issues should be closed when your PR is merged, e.g. fixes #123.
+
+### Additional context
+
+<!-- e.g. is there anything you'd like reviewers to focus on? -->
+
+---
+
+### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->
+
+- [ ] Bug fix
+- [ ] New Feature
+- [ ] Documentation update
+- [ ] Other
+
+### Before submitting the PR, please make sure you do the following:
+
+- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
+- [ ] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
+- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
+- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,25 @@
+# .github/workflows/publish-npm.yml
+# This workflow pushes new published releases to https://www.npmjs.com using
+# the Yarn Package Manager.
+name: Publish package to npmjs (using Yarn)
+on:
+  release:
+    types: [published]
+  workflow_call:
+    secrets:
+      NPM_TOKEN:
+        required: true
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18.16.x' # Use LTS
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@octocat'
+      - run: yarn
+      - run: yarn npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,30 @@
+# .github/workflows/release-please.yml
+# This workflow handles the release-please system that manages releasing new versions.
+# It also calls `publish-npm.yml`, which then handles publishing to npmjs.
+# See: https://github.com/googleapis/release-please
+name: release-please
+on:
+  push:
+    branches:
+      - main
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+    steps:
+      - uses: google-github-actions/release-please-action@v3 # Handle local releases
+        id: release
+        with:
+          release-type: node
+          package-name: bim-fragment
+  publish-npm:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created }}
+    uses: ./.github/workflows/publish-npm.yml # Publish to npmjs
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }} 
+    # Publish only if release-please creates a published release

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,8 +1,6 @@
 name: tests
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
 
@@ -13,12 +11,12 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [18.x]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - run: yarn install

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 [![NPM Package][npm-downloads]][npm-url]
 [![NPM Package][oc-contributors]][oc]
 [![Discord][discord]][discord-url]
-[![Tests](https://github.com/IFCjs/fragment/actions/workflows/tests.yaml/badge.svg)](https://github.com/IFCjs/fragment/actions/workflows/tests.yaml)
+[![Tests](https://github.com/IFCjs/fragment/actions/workflows/tests.yml/badge.svg)](https://github.com/IFCjs/fragment/actions/workflows/tests.yml)
 
 This library is a geometric API based on [Three.js](https://github.com/mrdoob/three.js/) and other libraries to efficiently display built environment data.
 


### PR DESCRIPTION
**NOTE:** don't merge this yet! It still has to be re-read and reviewed by the PR author, @oxcabe.
This PR integrates the same organizational/operations changes that have been implemented in the [IFCjs/components](https://github.com/IFCjs/components) repo, including:

* Templates for issues and PRs.
* Workflows that automate releasing procedures.
* An updated test workflow.

The final intention of this commit is to match the capabilities of those that have already been made available in the aforementioned *components* repo.